### PR TITLE
Use a modal, cut upload process in two steps, copy url feature

### DIFF
--- a/css/vimeo_upload.css
+++ b/css/vimeo_upload.css
@@ -1,43 +1,89 @@
-.vimeo-upload .container {
-  width: auto;
-  max-width: 680px;
-  padding: 0 15px;
-}
+/**
+ * @file
+ * Vimedo upload form styling.
+ */
 
-.vimeo-upload .container .text-muted {
-  margin: 20px 0;
-}
-
-.vimeo-upload .form-control {
-  margin-bottom: 15px;
-  padding: 3px;
-}
-
-.vimeo-upload input[type=text],
-.vimeo-upload textarea {
-  width: 350px;
-}
-
-.vimeo-upload #progress-container {
-  -webkit-box-shadow: none;
-  box-shadow: inset;
+.vimeo-upload__group {
   display: none;
 }
 
-.vimeo-upload #drop_zone {
-  border: 2px dashed #bbb;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px;
-  padding-top: 60px;
-  text-align: center;
-  font: 20pt bold;
-  color: #bbb;
-  height: 140px;
+.vimeo-upload__drop-zone,
+.vimeo-upload .form-textarea,
+.vimeo-upload .form-text {
+  max-width: 30rem;
+  width: 100%;
 }
 
-.vimeo-upload #video-data {
-  margin-top: 1em;
-  font-size: 1.1em;
-  font-weight: 500;
+.vimeo-upload__drop-zone {
+  align-items: center;
+  border-radius: 5px;
+  border: 2px dashed #bbb;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  min-height: 140px;
+  padding: 1em;
+  text-align: center;
+  transition: all 250ms cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.vimeo-upload__drop-zone-text-uploading {
+  display: none;
+  width: 50%;
+}
+
+.vimeo-upload__url {
+  display: flex;
+}
+
+.vimeo-upload__url .form-text {
+  flex: 1;
+}
+
+.vimeo-upload .alert p {
+  margin-top: 0;
+}
+
+/* States */
+
+.vimeo-upload__group.is-visible {
+  display: block;
+  animation: fadeIn 400ms;
+}
+
+.vimeo-upload__drop-zone.is-hovered {
+  border-color: blue;
+  color: blue;
+}
+
+/* Avoid firing events when :hovering children. */
+.vimeo-upload__drop-zone.is-hovered * {
+  pointer-events: none;
+}
+
+.is-done .vimeo-upload__drop-zone-text-drop,
+.is-uploading .vimeo-upload__drop-zone-text-drop,
+.is-hovered .vimeo-upload__drop-zone-text-drop {
+  display: none;
+}
+
+.vimeo-upload__drop-zone-text-hover,
+.vimeo-upload__drop-zone-text-uploading,
+.vimeo-upload__drop-zone-text-done {
+  display: none;
+}
+
+.is-uploading .vimeo-upload__drop-zone-text-uploading,
+.is-done .vimeo-upload__drop-zone-text-done,
+.is-hovered .vimeo-upload__drop-zone-text-hover {
+  display: block;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/js/vimeo_upload.js
+++ b/js/vimeo_upload.js
@@ -3,103 +3,28 @@
  * Attaches behaviors for Vimeo Upload.
  */
 
-(function ($, Drupal) {
-
+(($, Drupal) => {
   Drupal.behaviors.vimeoUploadBehavior = {
-    attach: function (context, settings) {
+    attach(context, settings) {
+      /* @todo Standardize javascript usage (ES5,ES6, jQuery). */
 
-      var access_token = settings.access_token
+      const accessToken = settings.access_token;
 
-      /**
-       * Called when files are dropped on to the drop target or selected by the browse button.
-       * For each file, uploads the content to Drive & displays the results when complete.
-       */
-      function handleFileSelect(evt) {
-        evt.stopPropagation()
-        evt.preventDefault()
-
-        var files = evt.dataTransfer ? evt.dataTransfer.files : $(this).get(0).files
-        var results = document.getElementById('results')
-
-        // Clear the results div.
-        while (results.hasChildNodes()) results.removeChild(results.firstChild)
-        // Clear the video Url and hide it.
-        var videoUrlInput = document.getElementById('videoUrl')
-        videoUrlInput.value = '';
-        videoUrlInput.style.display = 'none';
-
-        // Rest the progress bar and show it.
-        updateProgress(0)
-        document.getElementById('progress-container').style.display = 'block'
-
-        // Instantiate Vimeo Uploader.
-        ;(new VimeoUpload({
-          name: document.getElementById('videoName').value,
-          description: document.getElementById('videoDescription').value,
-          private: document.getElementById('make_private').checked,
-          file: files[0],
-          token: access_token,
-          upgrade_to_1080: document.getElementById('upgrade_to_1080').checked,
-          onError: function(data) {
-            showMessage('<strong>Error</strong>: ' + JSON.parse(data).error, 'danger')
-          },
-          onProgress: function(data) {
-            updateProgress(data.loaded / data.total)
-          },
-          onComplete: function(videoId, index) {
-            var url = 'https://vimeo.com/' + videoId
-
-            if (index > -1) {
-              // The metadata contains all of the uploaded video(s) details see:
-              // https://developer.vimeo.com/api/endpoints/videos#/{video_id}
-              url = this.metadata[index].link //
-
-              // Add stringify the json object for displaying in a text area.
-              var pretty = JSON.stringify(this.metadata[index], null, 2)
-
-              console.log(pretty) /* echo server data */
-            }
-
-            // Display the success message and the video url.
-            // @todo make it translatable
-            var successMessage = '<p><strong>Upload Successful</strong>.</p>';
-            if(document.getElementById('make_private').checked) {
-              successMessage += '<p>Note that this video has been set as private, so you must be logged in with the Vimeo channel account to view it.</p>';
-            }
-            successMessage += '<p>You can now copy the URL.</p>';
-            showMessage(successMessage);
-            videoUrlInput.value = url;
-            videoUrlInput.style.display = 'block';
-          }
-        })).upload()
-
-        /**
-         * Shows a message.
-         *
-         * @param html
-         * @param type
-         */
-        function showMessage(html, type) {
-          /* hide progress bar */
-          document.getElementById('progress-container').style.display = 'none'
-
-          /* display alert message */
-          var element = document.createElement('div')
-          element.setAttribute('class', 'alert alert-' + (type || 'success'))
-          element.innerHTML = html
-          results.appendChild(element)
-        }
-      }
+      /* @todo move contents in settings */
+      const textError = Drupal.t("Error");
+      const textSuccess = Drupal.t("Upload Successful");
+      const textPrivate = Drupal.t(
+        "Note that this video has been set as private, so you must be logged in with the Vimeo channel account to view it."
+      );
+      const textCopyUrl = Drupal.t("You can now copy the URL.");
+      const textCopied = Drupal.t("Copied!");
 
       /**
-       * Dragover handler to set the drop effect.
-       *
-       * @param evt
+       * Display the progressbar
        */
-      function handleDragOver(evt) {
-        evt.stopPropagation()
-        evt.preventDefault()
-        evt.dataTransfer.dropEffect = 'copy'
+      function showProgress() {
+        document.getElementById("drop_zone").classList.remove("is-hovered");
+        document.getElementById("drop_zone").classList.add("is-uploading");
       }
 
       /**
@@ -108,24 +33,211 @@
        * @param progress
        */
       function updateProgress(progress) {
-        progress = Math.floor(progress * 100)
-        var element = document.getElementById('progress')
-        element.setAttribute('style', 'width:' + progress + '%')
-        element.innerHTML = '&nbsp;' + progress + '%'
+        progress = Math.floor(progress * 100);
+        const progressBar = document.getElementById("progress-bar");
+        const progressPercentage = document.getElementById(
+          "progress-percentage"
+        );
+        progressBar.setAttribute("style", `width:${progress}%`);
+        progressPercentage.innerHTML = `&nbsp;${progress}%`;
+      }
+
+      /**
+       * Shows a message.
+       *
+       * @param html
+       * @param type
+       */
+      function showMessage(html, type) {
+        /* display alert message */
+        const element = document.createElement("div");
+        element.setAttribute("class", `alert alert-${type || "success"}`);
+        element.innerHTML = html;
+        const results = document.getElementById("results");
+        results.appendChild(element);
+        const progressResults = document.getElementById("progress-results");
+        document.getElementById("drop_zone").classList.add("is-done");
+        document.getElementById("drop_zone").classList.remove("is-uploading");
+      }
+
+      /**
+       * Called when files are dropped on to the drop target or selected by the browse button.
+       * For each file, uploads the content to Drive & displays the results when complete.
+       *
+       * @param evt
+       */
+
+      function handleFileSelect(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+
+        const files = evt.dataTransfer
+          ? evt.dataTransfer.files
+          : $(this).get(0).files;
+        const results = document.getElementById("results");
+
+        // Clear the results div.
+        while (results.hasChildNodes()) results.removeChild(results.firstChild);
+        // Clear the video Url and hide it.
+        const videoUrlInput = document.getElementById("videoUrl");
+        videoUrlInput.value = "";
+
+        // Rest the progress bar and show it.
+        showProgress();
+        updateProgress(0);
+
+        // Disable the previous button
+        $(".vimeo-upload__prev").attr("disabled", true);
+
+        // Instantiate Vimeo Uploader.
+        new VimeoUpload({
+          name: document.getElementById("videoName").value,
+          description: document.getElementById("videoDescription").value,
+          private: document.getElementById("make_private").checked,
+          file: files[0],
+          token: accessToken,
+          upgrade_to_1080: document.getElementById("upgrade_to_1080").checked,
+          onError(data) {
+            showMessage(
+              `<strong>${textError}</strong>: ${JSON.parse(data).error}`,
+              "danger"
+            );
+          },
+          onProgress(data) {
+            updateProgress(data.loaded / data.total);
+          },
+          onComplete(videoId, index) {
+            $(".vimeo-upload__prev").removeAttr("disabled");
+            let url = `https://vimeo.com/${videoId}`;
+
+            if (index > -1) {
+              // The metadata contains all of the uploaded video(s) details see:
+              // https://developer.vimeo.com/api/endpoints/videos#/{video_id}
+              url = this.metadata[index].link;
+
+              // Add stringify the json object for displaying in a text area.
+              const pretty = JSON.stringify(this.metadata[index], null, 2);
+            }
+
+            // Display the success message and the video url.
+            let successMessage = `<p><strong>${textSuccess}</strong>.</p>`;
+            if (document.getElementById("make_private").checked) {
+              successMessage += `<p>${textPrivate}</p>`;
+            }
+            successMessage += `<p>${textCopyUrl}</p>`;
+            showMessage(successMessage);
+            videoUrlInput.value = url;
+          }
+        }).upload();
+      }
+
+      /**
+       * Dragover handler to set the drop effect.
+       *
+       * @param evt
+       */
+      function handleDragOver(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+        evt.dataTransfer.dropEffect = "copy";
+        this.classList.add("is-hovered");
+      }
+
+      /**
+       * Dragleave handler to unset the drop effect.
+       *
+       * @param evt
+       */
+      function handleDragLeave(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+        this.classList.remove("is-hovered");
+      }
+
+      /**
+       * Check if all required fields are filled.
+       */
+      function validateFormGroup() {
+        const $searchInputs = $(".vimeo-upload__required");
+        const $nextButton = $(".vimeo-upload__next");
+
+        let isValid = true;
+        $searchInputs.each(function() {
+          if ($(this).val() === "") isValid = false;
+        });
+        isValid
+          ? $nextButton.removeAttr("disabled")
+          : $nextButton.attr("disabled", true);
+      }
+
+      /**
+       * Go to next tab.
+       */
+      function goToNextTab() {
+        $step = $(this).data("step");
+        $nextStep = $step + 1;
+
+        document.getElementById("drop_zone").classList.remove("is-done");
+        document.getElementById("drop_zone").classList.remove("is-uploading");
+
+        $(`.vimeo-upload__group[data-step="${$step}"]`).removeClass(
+          "is-visible"
+        );
+        $(`.vimeo-upload__group[data-step="${$nextStep}"]`).addClass(
+          "is-visible"
+        );
+      }
+
+      /**
+       * Go to previous tab.
+       */
+      function goToPrevTab() {
+        $step = $(this).data("step");
+        $prevStep = $step - 1;
+
+        $(`.vimeo-upload__group[data-step="${$step}"]`).removeClass(
+          "is-visible"
+        );
+        $(`.vimeo-upload__group[data-step="${$prevStep}"]`).addClass(
+          "is-visible"
+        );
+      }
+
+      /**
+       * Copy url.
+       */
+      function copyUrl() {
+        $input = $(this).prev("input");
+        $input.focus();
+        $input.select();
+        document.execCommand("copy");
+        $(this).text(textCopied);
       }
 
       /**
        * Wire up drag & drop listeners once page loads.
        */
-      $(context).find('.vimeo-upload').once('vimeoUploadBehavior').each(function () {
-        var dropZone = document.getElementById('drop_zone')
-        var browse = document.getElementById('browse')
-        document.getElementById('videoUrl').style.display = 'none';
-        dropZone.addEventListener('dragover', handleDragOver, false)
-        dropZone.addEventListener('drop', handleFileSelect, false)
-        browse.addEventListener('change', handleFileSelect, false)
-      });
+      $(context)
+        .find(".vimeo-upload__content")
+        .once("vimeoUploadBehavior")
+        .each(() => {
+          const dropZone = document.getElementById("drop_zone");
+          const browse = document.getElementById("browse");
+
+          $(".vimeo-upload__required").each(() => {
+            $(this).keyup(validateFormGroup);
+            $(this).change(validateFormGroup);
+          });
+
+          $(".vimeo-upload__next").bind("click", goToNextTab);
+          $(".vimeo-upload__prev").bind("click", goToPrevTab);
+          $(".vimeo-upload__url-button").bind("click", copyUrl);
+
+          dropZone.addEventListener("dragover", handleDragOver, false);
+          dropZone.addEventListener("dragleave", handleDragLeave, false);
+          dropZone.addEventListener("drop", handleFileSelect, false);
+          browse.addEventListener("change", handleFileSelect, false);
+        });
     }
   };
-
 })(jQuery, Drupal);

--- a/templates/vimeo-upload.html.twig
+++ b/templates/vimeo-upload.html.twig
@@ -1,42 +1,60 @@
-<div class="container vimeo-upload">
-  <p class="lead">{{ 'Drag your video file into the dotted area below to upload it to your Vimeo channel.'|t }}</p>
-  <div id="progress-container" class="progress">
-    <div id="progress" class="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="46" aria-valuemin="0" aria-valuemax="100" style="width: 0%">&nbsp;0%
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <div id="results"></div>
-      <div class="form-group">
-        <input type="text" name="name" id="videoUrl" class="form-control" placeholder="" value="" readonly>
+<div class="vimeo-upload">
+  <div class="vimeo-upload__content">
+    <div class="vimeo-upload__group is-visible" data-step="1">
+      <p>{{ 'Upload a video on Vimeo and get its URL.'|t }}</p>
+      <div class="form-item">
+        <label for="videoName">{{ "Name"|t }}</label>
+        <input type="text" name="name" id="videoName" class="form-text vimeo-upload__required" placeholder="{{ "Video name"|t }}">
       </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-8">
-      <div class="form-group">
-        <input type="text" name="name" id="videoName" class="form-control" placeholder="Video name" value="">
+      <div class="form-item">
+        <label for="videoDescription">{{ "Description"|t }}</label>
+        <textarea name="description" id="videoDescription" class="form-textarea vimeo-upload__required" placeholder="{{ "Video description"|t }}"></textarea>
       </div>
-      <div class="form-group">
-        <textarea name="description" id="videoDescription" class="form-control" placeholder="Video description" value=""></textarea>
-      </div>
-      <div class="checkbox">
+      <div class="form-item">
         <label>
-          <input type="checkbox" id="upgrade_to_1080" name="upgrade_to_1080"> {{ 'Upgrade to 1080'|t }}
+          <input type="checkbox" id="upgrade_to_1080" name="upgrade_to_1080"> {{ "Upgrade to 1080"|t }}
         </label>
       </div>
-      <div class="checkbox">
+      <div class="form-item">
         <label>
-          <input type="checkbox" id="make_private" name="make_private" checked> {{ 'Make Private'|t }}
+          <input type="checkbox" id="make_private" name="make_private" class="form-checkbox" checked> {{ "Make Private"|t }}
         </label>
       </div>
+      <div class="form-actions">
+        <button class="button vimeo-upload__next" disabled data-step="1">{{ "Next"|t }}</button>
+      </div>
     </div>
-    <div class="col-md-4">
-      <div id="drop_zone">{{ 'Drop file here'|t }}</div>
-      <br/>
-      <label class="btn btn-block btn-info">
-        Browse&hellip; <input id="browse" type="file" style="display: none;">
-      </label>
+
+    <div class="vimeo-upload__group" data-step="2">
+      <div class="form-item">
+        <div id="drop_zone" class="vimeo-upload__drop-zone">
+          <div class="vimeo-upload__drop-zone-text-drop">
+            {{ 'Drop a video file here or'|t }}
+            <label class="button">
+              {{ "Select a file"|t }} <input id="browse" type="file" style="display: none;">
+            </label>
+          </div>
+          <div class="vimeo-upload__drop-zone-text-hover">
+            {{ 'Drop to upload'|t }}
+          </div>
+          <div class="vimeo-upload__drop-zone-text-uploading progress" id="progress-container">
+            <div class="progress__track">
+              <div class="progress__bar" id="progress-bar" role="progressbar" style="width: 0%"></div>
+            </div>
+            <div class="progress__percentage" id="progress-percentage">57%</div>
+          </div>
+          <div class="vimeo-upload__drop-zone-text-done" id="progress-results">
+            <div id="results"></div>
+            <div class="vimeo-upload__url">
+              <input type="text" name="name" class="form-text" id="videoUrl" readonly>
+              <button class="button vimeo-upload__url-button" data-step="2">{{ "Copy url"|t }}</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="form-actions">
+        <button class="button vimeo-upload__prev" data-step="2">{{ "Previous"|t }}</button>
+      </div>
     </div>
   </div>
 </div>

--- a/vimeo_upload.module
+++ b/vimeo_upload.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Serialization\Json;
 
 /**
  * Define the Vimeo Upload library location.
@@ -53,9 +54,23 @@ function vimeo_upload_field_widget_video_embed_field_textfield_form_alter(&$elem
     'vimeo_upload.upload',
     [],
     [
-      'attributes' => ['target' => '_blank'],
+      'attributes' => [
+        'class' => 'use-ajax',
+        'data-dialog-type' => 'modal',
+        'data-dialog-options' => Json::encode(
+          [
+            'height' => 400,
+            'width' => 480,
+          ]),
+      ],
+      'attached' => [
+        'library' => [
+          'core/drupal.dialog.ajax',
+        ],
+      ],
     ]);
   $link = $link->toRenderable();
+
   $element['vimeo_upload_link'] = [
     '#type' => 'item',
     '#markup' => \Drupal::service('renderer')->renderRoot($link),


### PR DESCRIPTION
Here is a proposal with a few improvements

- open `/admin/vimeo_upload/upload` in a modal instead of a new tab ("Drupal off_canvas
dialog" did not look so great so we sticked with the modal box instead)
- upload process has been cut in two steps so the user didn't forget to fill the Name and Description field before uploading)
- a "copy url" button at the end of the process
- translation for all .twig and .js strings
- follow BEM convention for css
- use a progress bar
- use labels for input text
- set a markup a bit closer from Drupal default output

Note the javascript could be standardized (ES5, ES6, jQuery), we set a @todo to mention that.

![vimeouploadprocess](https://user-images.githubusercontent.com/2854065/48341533-95920a80-e66d-11e8-9226-347be34a1c40.gif)
