### PR TITLE
Roll back Arrow Function

### DIFF
--- a/css/vimeo_upload.css
+++ b/css/vimeo_upload.css
@@ -1,6 +1,6 @@
 /**
  * @file
- * Vimedo upload form styling.
+ * Vimeo upload form styling.
  */
 
 .vimeo-upload__group {

--- a/js/vimeo_upload.js
+++ b/js/vimeo_upload.js
@@ -165,6 +165,7 @@
         $searchInputs.each(function() {
           if ($(this).val() === "") isValid = false;
         });
+
         isValid
           ? $nextButton.removeAttr("disabled")
           : $nextButton.attr("disabled", true);
@@ -220,11 +221,11 @@
       $(context)
         .find(".vimeo-upload__content")
         .once("vimeoUploadBehavior")
-        .each(() => {
+        .each(function() {
           const dropZone = document.getElementById("drop_zone");
           const browse = document.getElementById("browse");
 
-          $(".vimeo-upload__required").each(() => {
+          $(".vimeo-upload__required").each(function() {
             $(this).keyup(validateFormGroup);
             $(this).change(validateFormGroup);
           });


### PR DESCRIPTION
Removed es6 arrow function to stay compatible with older D8 version.
Also fixed a small typo.

This is already correct on Drupal project.
https://cgit.drupalcode.org/vimeo_upload/diff/js/vimeo_upload.js?h=8.x-1.x&id=ed08d11